### PR TITLE
0.5.0 - Return component from #cacheComponent. Add logging/options.

### DIFF
--- a/demo-conductor/src/main/kotlin/com/brandongogetap/scoper/conductordemo/base/MyApplication.kt
+++ b/demo-conductor/src/main/kotlin/com/brandongogetap/scoper/conductordemo/base/MyApplication.kt
@@ -11,7 +11,7 @@ class MyApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        Scoper.cacheComponent(SCOPE_TAG, DaggerApplicationComponent.builder()
+        Scoper.cacheComponent<ApplicationComponent>(SCOPE_TAG, DaggerApplicationComponent.builder()
                 .applicationModule(ApplicationModule(this))
                 .build())
     }

--- a/demo-fragment/src/main/kotlin/com/brandongogetap/scoper/fragmentdemo/base/MyApplication.kt
+++ b/demo-fragment/src/main/kotlin/com/brandongogetap/scoper/fragmentdemo/base/MyApplication.kt
@@ -11,7 +11,7 @@ class MyApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        Scoper.cacheComponent(SCOPE_TAG, DaggerApplicationComponent.builder()
+        Scoper.cacheComponent<ApplicationComponent>(SCOPE_TAG, DaggerApplicationComponent.builder()
                 .applicationModule(ApplicationModule(this))
                 .build())
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=0.4.0
+PROJECT_VERSION=0.5.0
 PROJECT_GROUP_ID=com.brandongogetap
 PROJECT_VCS_URL=https://github.com/bgogetap/Scoper.git
 PROJECT_DESCRIPTION=Scoper - A lightweight library that assists in handling scoped Dagger 2 Components

--- a/scoper/build.gradle
+++ b/scoper/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile 'org.robolectric:robolectric:3.0'
 
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/scoper/src/main/java/com/brandongogetap/scoper/Logger.java
+++ b/scoper/src/main/java/com/brandongogetap/scoper/Logger.java
@@ -1,0 +1,24 @@
+package com.brandongogetap.scoper;
+
+import android.util.Log;
+
+final class Logger {
+
+    private boolean enabled = false;
+
+    void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    void w(String message) {
+        if (enabled) {
+            Log.w("Scoper", message);
+        }
+    }
+
+    void d(String message) {
+        if (enabled) {
+            Log.d("Scoper", message);
+        }
+    }
+}

--- a/scoper/src/main/java/com/brandongogetap/scoper/Scoper.java
+++ b/scoper/src/main/java/com/brandongogetap/scoper/Scoper.java
@@ -87,9 +87,11 @@ import android.support.annotation.NonNull;
      *
      * @param scopeName Scope name associated with the component
      * @param component Component to cache
+     * @return The provided component
      */
-    public static void cacheComponent(String scopeName, Object component) {
-        CacheHandler.INSTANCE.cacheComponent(scopeName, component);
+    @NonNull
+    public static <T> T cacheComponent(String scopeName, @NonNull Object component) {
+        return CacheHandler.INSTANCE.cacheComponent(scopeName, component);
     }
 
     /**
@@ -112,11 +114,20 @@ import android.support.annotation.NonNull;
         CacheHandler.INSTANCE.destroyScope(scopeName);
     }
 
+    /**
+     * Toggle debug console logging.
+     * @param enabled Whether or not to log debug messages. Default is off (false).
+     */
+    public static void loggingEnabled(boolean enabled) {
+        CacheHandler.INSTANCE.loggingEnabled(enabled);
+    }
+
     @SuppressWarnings("unchecked")
     private enum CacheHandler {
         INSTANCE;
 
-        private ScoperCache cache = new ScoperCache();
+        private Logger logger = new Logger();
+        private ScoperCache cache = new ScoperCache(logger);
 
         <T> T createComponent(Context context, Object component) {
             return (T) cache.initComponent(context, component);
@@ -130,8 +141,8 @@ import android.support.annotation.NonNull;
             return (T) cache.getComponentForTag(tag);
         }
 
-        void cacheComponent(String tag, Object component) {
-            cache.put(tag, component);
+        <T> T cacheComponent(String tag, Object component) {
+            return (T) cache.put(tag, component);
         }
 
         void destroyScope(Context context) {
@@ -144,6 +155,10 @@ import android.support.annotation.NonNull;
 
         void replaceExisting(boolean replaceExisting) {
             cache.replaceExisting(replaceExisting);
+        }
+
+        void loggingEnabled(boolean enabled) {
+            logger.setEnabled(enabled);
         }
     }
 }

--- a/scoper/src/test/java/com/brandongogetap/scoper/ScoperCacheRobot.java
+++ b/scoper/src/test/java/com/brandongogetap/scoper/ScoperCacheRobot.java
@@ -11,7 +11,7 @@ final class ScoperCacheRobot {
     private final ScoperCache cache;
 
     ScoperCacheRobot() {
-        this.cache = new ScoperCache();
+        this.cache = new ScoperCache(new Logger());
     }
 
     ScoperCacheRobot initComponent(String tag, Object component) {
@@ -64,7 +64,13 @@ final class ScoperCacheRobot {
         return this;
     }
 
+    ScoperCacheRobot putReturnsCreated(String tag, Object component) {
+        assertEquals(cache.put(tag, component), component);
+        return this;
+    }
+
     private ScoperContext getScoperContextForTag(String tag) {
         return new ScoperContext(Mockito.mock(Context.class), tag);
     }
+
 }

--- a/scoper/src/test/java/com/brandongogetap/scoper/ScoperCacheTest.java
+++ b/scoper/src/test/java/com/brandongogetap/scoper/ScoperCacheTest.java
@@ -132,4 +132,12 @@ public class ScoperCacheTest {
                 .initComponent(context, secondInstance)
                 .checkComponentEquals(context, secondInstance);
     }
+
+    @Test
+    public void createdComponentReturned() {
+        Object firstComponent = new Object();
+        Object secondComponent = new Object();
+        robot.putReturnsCreated("first", firstComponent)
+                .putReturnsCreated("first", secondComponent);
+    }
 }


### PR DESCRIPTION
Returning provided component from `Scoper#cacheComponent` to allow for chained inject call.

Not sure I am convinced because of having to provide type parameters when using it now, but I think the convenience is worth it.

This is also a method that should really only be called in the Application scoped component. Everywhere else should be passing around `ScoperContext` instances which renders this method obsolete.
